### PR TITLE
Fix doc link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Generated files are created by a build script (see section [How to build](#how-t
 A Subset of this `DevWorkspace` API defines a structure (workspace template content), which is also at the core of the **Devfile 2.0** format specification.
 For more information about this, please look into the [Devfile support README](https://github.com/devfile/registry-support/blob/main/README.md)
 
-The generated documentation of the Devfile 2.0 format, based on its json schema, is available [here](https://devfile.github.io).
+You can read the available generated [documentation of the Devfile 2.0 format](https://devfile.io/docs/2.3.0/devfile-schema), based on its json schema.
 
 Typescript model is build on each commit of main branch and available as an [NPM package](https://www.npmjs.com/package/@devfile/api).
 


### PR DESCRIPTION
# Description of Changes
Updating the link to the generated documentation. Rephrasing to avoid using `here` for link text to have more [readable links](https://accessibility.huit.harvard.edu/technique-writing-link-text).

# Related Issue(s)
fixes #1688

# Acceptance Criteria

If criteria is left unchecked please provide an explanation why.

- [x] Unit/Functional tests

No code changes

- [x] [QE Integration test](https://github.com/devfile/integration-tests)

No code changes

- [x] Documentation

Updating link

- [x] Client Impact

No code changes

# Tests Performed
Clicked link.

# How To Test
Click the link and don't end up with a dead page.

# Notes To Reviewer
Feel free to rephrase if you don't like my wording.
